### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@
     warnings,
     unused_variables,
     missing_docs,
-    unsafe_code,
     unused_extern_crates
 )]
+#![forbid(unsafe_code)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
 //! Voca_rs is the ultimate Rust string library inspired by Voca.js and string.py


### PR DESCRIPTION
Switch from the deny to the forbid level for unsafe code to get a clean report from `cargo geiger`. This prevents any local exception annotations over the deny lint level.

```
$ cargo geiger
...
Metric output format: x/y
    x = unsafe code used by the build
    y = total unsafe code found in the crate

Symbols: 
    🔒  = No `unsafe` usage found, declares #![forbid(unsafe_code)]
    ❓  = No `unsafe` usage found, missing #![forbid(unsafe_code)]
    ☢️   = `unsafe` usage found

Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        0/0          0/0    0/0     0/0      🔒 voca_rs 1.15.0
0/0        34/34        1/2    0/0     2/2      ☢️  ├── regex 1.7.0
19/19      678/678      0/0    0/0     22/22    ☢️  │   ├── aho-corasick 0.7.18
36/37      2067/2140    0/0    0/0     16/16    ☢️  │   │   └── memchr 2.4.1
36/37      2067/2140    0/0    0/0     16/16    ☢️  │   ├── memchr 2.4.1
0/0        0/0          0/0    0/0     0/0      🔒 │   └── regex-syntax 0.6.28
0/0        0/0          0/0    0/0     0/0      ❓ ├── stfu8 0.2.5
0/0        7/7          1/1    0/0     0/0      ☢️  │   ├── lazy_static 1.4.0
0/0        34/34        1/2    0/0     2/2      ☢️  │   └── regex 1.7.0
0/0        0/0          0/0    0/0     0/0      ❓ └── unicode-segmentation 1.10.0

55/56      2786/2859    2/3    0/0     40/40  
```