### PR TITLE
Add bounds checks to strip_html_tags

### DIFF
--- a/src/strip.rs
+++ b/src/strip.rs
@@ -80,7 +80,7 @@ fn strip_html_tags(subject: &str) -> String {
     let mut quote = String::with_capacity(4);
     for (i, c) in crate::split::graphemes(subject).iter().enumerate() {
         let mut advance = false;
-        match c.to_owned() {
+        match *c {
             "<" => {
                 if !quote.is_empty() {
                 } else if crate::query::query(

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -83,11 +83,13 @@ fn strip_html_tags(subject: &str) -> String {
         match *c {
             "<" => {
                 if !quote.is_empty() {
-                } else if crate::query::query(
-                    unicode_string_range(subject, i, i + 2).as_str(),
-                    "< ",
-                    0,
-                ) {
+                } else if i + 2 < length
+                    && crate::query::query(
+                        unicode_string_range(subject, i, i + 2).as_str(),
+                        "< ",
+                        0,
+                    )
+                {
                     advance = true;
                 } else if state == StateMode::Output {
                     advance = true;
@@ -100,6 +102,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "!" => {
                 if state == StateMode::Html
+                    && i + 2 < length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 2).as_str(),
                         "<!",
@@ -113,6 +116,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "-" => {
                 if state == StateMode::Exclamation
+                    && i + 3 < length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 3).as_str(),
                         "!--",
@@ -138,6 +142,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "E" | "e" => {
                 if state == StateMode::Exclamation
+                    && i + 7 < length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 7).as_str(),
                         "doctype",
@@ -156,6 +161,7 @@ fn strip_html_tags(subject: &str) -> String {
                 } else if state == StateMode::Html
                     || state == StateMode::Exclamation
                     || state == StateMode::Comment
+                        && i + 3 < length
                         && crate::query::query(
                             unicode_string_range(subject, i, i + 3).as_str(),
                             "-->",

--- a/tests/unit/strip.rs
+++ b/tests/unit/strip.rs
@@ -226,3 +226,13 @@ fn _strip_tags() {
         "Summer is nice"
     );
 }
+
+#[test]
+fn partial_directive() {
+    assert_eq!(voca_rs::strip::strip_tags("<"), "");
+    assert_eq!(voca_rs::strip::strip_tags("<t"), "");
+    assert_eq!(voca_rs::strip::strip_tags("</"), "");
+    assert_eq!(voca_rs::strip::strip_tags("</a"), "");
+    assert_eq!(voca_rs::strip::strip_tags("<!"), "");
+    assert_eq!(voca_rs::strip::strip_tags("<!-"), "");
+}


### PR DESCRIPTION
Check that there's sufficient look-ahead when checking for tags and other sgml markup, instead of panicing when a tag opens at the end of the provided string.

Resolves https://github.com/a-merezhanyi/voca_rs/issues/21
