### PR TITLE
Address outstanding clippy warnings

### DIFF
--- a/src/case.rs
+++ b/src/case.rs
@@ -20,7 +20,7 @@
 /// // => "birdFlight"
 /// ```
 pub fn camel_case(subject: &str) -> String {
-    camel_and_pascal_case(&subject, TitleMode::Normal)
+    camel_and_pascal_case(subject, TitleMode::Normal)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -32,7 +32,7 @@ enum TitleMode {
 fn camel_and_pascal_case(subject: &str, title_mode: TitleMode) -> String {
     return match subject.len() {
         0 => subject.to_string(),
-        _ => return_string(&subject, title_mode),
+        _ => return_string(subject, title_mode),
     };
 
     fn return_string(subject: &str, title_mode: TitleMode) -> String {
@@ -92,7 +92,7 @@ enum CapsMode {
 fn capitalize_decapitalize(subject: &str, rest_mode: RestMode, caps_mode: CapsMode) -> String {
     return match subject.len() {
         0 => subject.to_string(),
-        _ => return_string(&subject, rest_mode, caps_mode),
+        _ => return_string(subject, rest_mode, caps_mode),
     };
 
     fn return_string(subject: &str, rest_mode: RestMode, caps_mode: CapsMode) -> String {
@@ -163,7 +163,7 @@ pub fn decapitalize(subject: &str, rest_to_lower: bool) -> String {
 /// // => "goodbye-blue-sky"
 /// ```
 pub fn kebab_case(subject: &str) -> String {
-    kebab_and_shouty_kebab_and_train_case(&subject, KebabMode::Normal)
+    kebab_and_shouty_kebab_and_train_case(subject, KebabMode::Normal)
 }
 
 /// Converts the `subject` to SHOUTY kebab case.
@@ -186,7 +186,7 @@ pub fn kebab_case(subject: &str) -> String {
 /// // => "GOODBYE-BLUE-SKY"
 /// ```
 pub fn shouty_kebab_case(subject: &str) -> String {
-    kebab_and_shouty_kebab_and_train_case(&subject, KebabMode::Shouty)
+    kebab_and_shouty_kebab_and_train_case(subject, KebabMode::Shouty)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -202,9 +202,9 @@ fn kebab_and_shouty_kebab_and_train_case(subject: &str, kebab_mode: KebabMode) -
         _ => crate::split::words(subject)
             .into_iter()
             .map(|c| match kebab_mode {
-                KebabMode::Normal => lower_case(&c),
-                KebabMode::Shouty => upper_case(&c),
-                KebabMode::Train => capitalize(&c, true),
+                KebabMode::Normal => lower_case(c),
+                KebabMode::Shouty => upper_case(c),
+                KebabMode::Train => capitalize(c, true),
             })
             .collect::<Vec<String>>()
             .join("-"),
@@ -262,7 +262,7 @@ pub fn lower_case(subject: &str) -> String {
 /// // => "BirdFlight"
 /// ```
 pub fn pascal_case(subject: &str) -> String {
-    camel_and_pascal_case(&subject, TitleMode::Caps)
+    camel_and_pascal_case(subject, TitleMode::Caps)
 }
 
 /// Converts the `subject` to snake case.
@@ -285,7 +285,7 @@ pub fn pascal_case(subject: &str) -> String {
 /// // => "learning_to_fly"
 /// ```
 pub fn snake_case(subject: &str) -> String {
-    snake_and_shouty_snake_case(&subject, false)
+    snake_and_shouty_snake_case(subject, false)
 }
 
 /// Converts the `subject` to SHOUTY snake case.
@@ -308,7 +308,7 @@ pub fn snake_case(subject: &str) -> String {
 /// // => "LEARNING_TO_FLY"
 /// ```
 pub fn shouty_snake_case(subject: &str) -> String {
-    snake_and_shouty_snake_case(&subject, true)
+    snake_and_shouty_snake_case(subject, true)
 }
 
 fn snake_and_shouty_snake_case(subject: &str, shouty: bool) -> String {
@@ -318,9 +318,9 @@ fn snake_and_shouty_snake_case(subject: &str, shouty: bool) -> String {
             .into_iter()
             .map(|c| {
                 if shouty {
-                    upper_case(&c)
+                    upper_case(c)
                 } else {
-                    lower_case(&c)
+                    lower_case(c)
                 }
             })
             .collect::<Vec<String>>()
@@ -390,7 +390,7 @@ pub fn title_case(subject: &str) -> String {
         0 => subject.to_string(),
         _ => crate::split::words(subject)
             .into_iter()
-            .map(|c| capitalize(&c, true))
+            .map(|c| capitalize(c, true))
             .collect::<Vec<String>>()
             .join(" "),
     }
@@ -416,7 +416,7 @@ pub fn title_case(subject: &str) -> String {
 /// // => "Goodbye-Blue-Sky"
 /// ```
 pub fn train_case(subject: &str) -> String {
-    kebab_and_shouty_kebab_and_train_case(&subject, KebabMode::Train)
+    kebab_and_shouty_kebab_and_train_case(subject, KebabMode::Train)
 }
 
 /// Converts the `subject` to upper case.
@@ -469,7 +469,7 @@ pub fn upper_case(subject: &str) -> String {
 /// // => "fred"
 /// ```
 pub fn lower_first(subject: &str) -> String {
-    decapitalize(&subject, false)
+    decapitalize(subject, false)
 }
 
 /// Converts the first character of the `subject` to upper case.
@@ -491,5 +491,5 @@ pub fn lower_first(subject: &str) -> String {
 /// // => "Fred"
 /// ```
 pub fn upper_first(subject: &str) -> String {
-    capitalize(&subject, false)
+    capitalize(subject, false)
 }

--- a/src/chop.rs
+++ b/src/chop.rs
@@ -17,7 +17,7 @@ enum CharType {
 fn get_chars(subject: &str, start: usize, end: usize) -> String {
     match subject.len() {
         0 => subject.to_string(),
-        _ => crate::split::chars(&subject)[start..end].join(""),
+        _ => crate::split::chars(subject)[start..end].join(""),
     }
 }
 
@@ -58,16 +58,16 @@ fn return_after_or_before_and_after_last_or_before_last(
 ) -> String {
     let start_position = match return_type {
         ReturnType::AfterNormal | ReturnType::BeforeNormal => {
-            crate::index::index_of(&subject, &search, 0)
+            crate::index::index_of(subject, search, 0)
         }
         ReturnType::AfterLast | ReturnType::BeforeLast => {
-            crate::index::last_index_of(&subject, &search, 0)
+            crate::index::last_index_of(subject, search, 0)
         }
     } as isize;
     if start_position == -1 {
         return "".to_owned();
     }
-    let the_length = crate::count::count(&search) as isize;
+    let the_length = crate::count::count(search) as isize;
     let chop_start_position = match return_type {
         ReturnType::AfterNormal | ReturnType::AfterLast => start_position + the_length,
         ReturnType::BeforeNormal | ReturnType::BeforeLast => 0,
@@ -76,7 +76,7 @@ fn return_after_or_before_and_after_last_or_before_last(
         ReturnType::AfterNormal | ReturnType::AfterLast => 0,
         ReturnType::BeforeNormal | ReturnType::BeforeLast => start_position,
     };
-    crate::chop::slice(&subject, chop_start_position, chop_end_position)
+    crate::chop::slice(subject, chop_start_position, chop_end_position)
 }
 /// Returns everything after the given `search`.
 ///
@@ -100,8 +100,8 @@ pub fn after(subject: &str, search: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => return_after_or_before_and_after_last_or_before_last(
-            &subject,
-            &search,
+            subject,
+            search,
             ReturnType::AfterNormal,
         ),
     }
@@ -128,8 +128,8 @@ pub fn after_last(subject: &str, search: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => return_after_or_before_and_after_last_or_before_last(
-            &subject,
-            &search,
+            subject,
+            search,
             ReturnType::AfterLast,
         ),
     }
@@ -156,8 +156,8 @@ pub fn before(subject: &str, search: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => return_after_or_before_and_after_last_or_before_last(
-            &subject,
-            &search,
+            subject,
+            search,
             ReturnType::BeforeNormal,
         ),
     }
@@ -184,8 +184,8 @@ pub fn before_last(subject: &str, search: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => return_after_or_before_and_after_last_or_before_last(
-            &subject,
-            &search,
+            subject,
+            search,
             ReturnType::BeforeLast,
         ),
     }
@@ -210,7 +210,7 @@ pub fn before_last(subject: &str, search: &str) -> String {
 /// ```
 pub fn char_at(subject: &str, position: usize) -> String {
     let the_position = get_subject_length(subject, position, PointType::Position, CharType::Simple);
-    get_chars(&subject, the_position, the_position + 1)
+    get_chars(subject, the_position, the_position + 1)
 }
 
 /// Get the Unicode code point value of the character at `position`.
@@ -236,7 +236,7 @@ pub fn code_point_at(subject: &str, position: usize) -> Vec<u16> {
     if subject.is_empty() {
         return vec![];
     }
-    let grapheme = grapheme_at(&subject, position);
+    let grapheme = grapheme_at(subject, position);
     crate::split::code_points(&grapheme)
 }
 
@@ -264,7 +264,7 @@ pub fn first(subject: &str, length: usize) -> String {
     let the_length = get_subject_length(subject, length, PointType::Length, CharType::Simple);
     match length {
         0 => "".to_string(),
-        _ => get_chars(&subject, 0, the_length),
+        _ => get_chars(subject, 0, the_length),
     }
 }
 
@@ -333,7 +333,7 @@ pub fn grapheme_at(subject: &str, position: usize) -> String {
         _ => {
             let the_position =
                 get_subject_length(subject, position, PointType::Position, CharType::Grapheme);
-            crate::split::graphemes(&subject)[the_position].to_string()
+            crate::split::graphemes(subject)[the_position].to_string()
         }
     }
 }
@@ -362,10 +362,10 @@ pub fn last(subject: &str, length: usize) -> String {
     match length {
         0 => "".to_string(),
         _ => {
-            let subject_length = crate::split::chars(&subject).len();
+            let subject_length = crate::split::chars(subject).len();
             let the_length =
                 get_subject_length(subject, length, PointType::Length, CharType::Grapheme);
-            get_chars(&subject, subject_length - the_length, subject_length)
+            get_chars(subject, subject_length - the_length, subject_length)
         }
     }
 }
@@ -401,9 +401,9 @@ pub fn prune(subject: &str, length: usize, end: &str) -> String {
         "" => "...",
         _ => end,
     };
-    let subject_chars = crate::split::chars(&subject);
+    let subject_chars = crate::split::chars(subject);
     let subject_length = subject_chars.len();
-    let end_length = crate::split::chars(&suffix).len();
+    let end_length = crate::split::chars(suffix).len();
     let position_end = if subject_length <= length {
         suffix = "";
         subject_length
@@ -448,7 +448,7 @@ pub fn prune(subject: &str, length: usize, end: &str) -> String {
         end_position
     };
 
-    format!("{}{}", get_chars(&subject, 0, position_end), suffix)
+    format!("{}{}", get_chars(subject, 0, position_end), suffix)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -457,19 +457,19 @@ enum CutType {
     EndsWith,
 }
 fn remove_prefix_or_suffix(subject: &str, substring: &str, cut_type: CutType) -> String {
-    let substring_len = crate::count::count(&substring);
+    let substring_len = crate::count::count(substring);
     match substring_len {
         0 => subject.to_owned(),
         _ => {
             if cut_type == CutType::StartsWith {
-                if crate::query::starts_with(&subject, &substring) {
-                    crate::chop::after(&subject, &substring)
+                if crate::query::starts_with(subject, substring) {
+                    crate::chop::after(subject, substring)
                 } else {
                     subject.to_owned()
                 }
             } else {
-                if crate::query::ends_with(&subject, &substring) {
-                    crate::chop::before_last(&subject, &substring)
+                if crate::query::ends_with(subject, substring) {
+                    crate::chop::before_last(subject, substring)
                 } else {
                     subject.to_owned()
                 }
@@ -498,7 +498,7 @@ fn remove_prefix_or_suffix(subject: &str, substring: &str, cut_type: CutType) ->
 pub fn removeprefix(subject: &str, prefix: &str) -> String {
     match subject.len() {
         0 => subject.to_owned(),
-        _ => remove_prefix_or_suffix(&subject, &prefix, CutType::StartsWith),
+        _ => remove_prefix_or_suffix(subject, prefix, CutType::StartsWith),
     }
 }
 
@@ -523,7 +523,7 @@ pub fn removeprefix(subject: &str, prefix: &str) -> String {
 pub fn removesuffix(subject: &str, prefix: &str) -> String {
     match subject.len() {
         0 => subject.to_owned(),
-        _ => remove_prefix_or_suffix(&subject, &prefix, CutType::EndsWith),
+        _ => remove_prefix_or_suffix(subject, prefix, CutType::EndsWith),
     }
 }
 
@@ -553,7 +553,7 @@ pub fn removesuffix(subject: &str, prefix: &str) -> String {
 /// // => "iami"
 /// ```
 pub fn slice(subject: &str, start: isize, end: isize) -> String {
-    let subject_length = crate::split::chars(&subject).len();
+    let subject_length = crate::split::chars(subject).len();
     let position_start = calculate_position(subject_length, start, true);
     let position_end = calculate_position(subject_length, end, false);
 
@@ -578,7 +578,7 @@ pub fn slice(subject: &str, start: isize, end: isize) -> String {
         }
     }
 
-    get_chars(&subject, position_start, position_end)
+    get_chars(subject, position_start, position_end)
 }
 
 /// Extracts from `subject` a string from `start` position a number of `length` characters.
@@ -601,7 +601,7 @@ pub fn slice(subject: &str, start: isize, end: isize) -> String {
 /// // => "each"
 /// ```
 pub fn substr(subject: &str, start: usize, length: usize) -> String {
-    let subject_length = crate::split::chars(&subject).len();
+    let subject_length = crate::split::chars(subject).len();
     if start >= subject_length {
         return "".to_string();
     }
@@ -619,7 +619,7 @@ pub fn substr(subject: &str, start: usize, length: usize) -> String {
     if start >= position_end {
         return "".to_string();
     }
-    get_chars(&subject, start, position_end)
+    get_chars(subject, start, position_end)
 }
 
 /// Extracts from `subject` a string from `start` position up to `end` position. The character at `end` position is not included.
@@ -644,7 +644,7 @@ pub fn substr(subject: &str, start: usize, length: usize) -> String {
 /// // => "each"
 /// ```
 pub fn substring(subject: &str, start: usize, end: usize) -> String {
-    let subject_length = crate::split::chars(&subject).len();
+    let subject_length = crate::split::chars(subject).len();
     if start >= subject_length {
         return "".to_string();
     }
@@ -662,7 +662,7 @@ pub fn substring(subject: &str, start: usize, end: usize) -> String {
         return "".to_string();
     }
 
-    get_chars(&subject, start, position_end)
+    get_chars(subject, start, position_end)
 }
 
 /// Truncates `subject` to a new `length`.
@@ -694,15 +694,15 @@ pub fn truncate(subject: &str, length: usize, end: &str) -> String {
         "" => "...",
         _ => end,
     };
-    let subject_length = crate::split::chars(&subject).len();
-    let end_length = crate::split::chars(&suffix).len();
+    let subject_length = crate::split::chars(subject).len();
+    let end_length = crate::split::chars(suffix).len();
     let position_end = if subject_length < length || length < end_length {
         suffix = "";
         subject_length
     } else {
         length - end_length
     };
-    format!("{}{}", get_chars(&subject, 0, position_end), suffix)
+    format!("{}{}", get_chars(subject, 0, position_end), suffix)
 }
 
 /// Returns the max character from the `subject` by its code point.
@@ -729,7 +729,7 @@ pub fn max(subject: &str) -> String {
     if subject.is_empty() {
         return "".to_owned();
     }
-    min_max(&subject, MinMaxType::Max)
+    min_max(subject, MinMaxType::Max)
 }
 
 /// Returns the min character from the `subject` by its code point.
@@ -756,7 +756,7 @@ pub fn min(subject: &str) -> String {
     if subject.is_empty() {
         return "".to_owned();
     }
-    min_max(&subject, MinMaxType::Min)
+    min_max(subject, MinMaxType::Min)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -769,7 +769,7 @@ fn min_max(subject: &str, search_type: MinMaxType) -> String {
     if subject.is_empty() {
         return "".to_owned();
     }
-    let code_points = crate::split::code_points(&subject);
+    let code_points = crate::split::code_points(subject);
     let min_max = match search_type {
         MinMaxType::Max => code_points.iter().max(),
         MinMaxType::Min => code_points.iter().min(),

--- a/src/chop.rs
+++ b/src/chop.rs
@@ -467,12 +467,10 @@ fn remove_prefix_or_suffix(subject: &str, substring: &str, cut_type: CutType) ->
                 } else {
                     subject.to_owned()
                 }
-            } else {
-                if crate::query::ends_with(subject, substring) {
+            } else if crate::query::ends_with(subject, substring) {
                     crate::chop::before_last(subject, substring)
-                } else {
-                    subject.to_owned()
-                }
+            } else {
+                subject.to_owned()
             }
         }
     }

--- a/src/count.rs
+++ b/src/count.rs
@@ -85,7 +85,7 @@ pub fn count_substrings(subject: &str, substring: &str) -> usize {
 
     match subject.len() {
         0 => 0,
-        _ => match_substring(&subject, &substring),
+        _ => match_substring(subject, substring),
     }
 }
 
@@ -113,8 +113,8 @@ pub fn count_where(subject: &str, f: fn(&str) -> bool) -> usize {
         0 => 0,
         _ => {
             let mut res = 0;
-            for c in crate::split::graphemes(&subject).iter() {
-                if f(&c) {
+            for c in crate::split::graphemes(subject).iter() {
+                if f(c) {
                     res += 1;
                 }
             }
@@ -147,7 +147,7 @@ pub fn count_where(subject: &str, f: fn(&str) -> bool) -> usize {
 pub fn count_words(subject: &str, pattern: &str) -> usize {
     fn match_substring(subject: &str, pattern: &str) -> usize {
         match pattern.len() {
-            0 => crate::split::words(&subject).iter().count(),
+            0 => crate::split::words(subject).iter().count(),
             _ => subject
                 .split_terminator(pattern)
                 .collect::<Vec<_>>()
@@ -157,7 +157,7 @@ pub fn count_words(subject: &str, pattern: &str) -> usize {
     }
     match subject.len() {
         0 => 0,
-        _ => match_substring(&subject, &pattern),
+        _ => match_substring(subject, pattern),
     }
 }
 
@@ -184,7 +184,7 @@ use std::collections::HashMap;
 pub fn count_unique_words(subject: &str, pattern: &str) -> usize {
     let mut unique_words = HashMap::new();
     let words = match pattern.len() {
-        0 => crate::split::words(&subject),
+        0 => crate::split::words(subject),
         _ => subject.split_terminator(pattern).collect::<Vec<_>>(),
     };
     if words.len() == 0 {

--- a/src/count.rs
+++ b/src/count.rs
@@ -147,11 +147,9 @@ pub fn count_where(subject: &str, f: fn(&str) -> bool) -> usize {
 pub fn count_words(subject: &str, pattern: &str) -> usize {
     fn match_substring(subject: &str, pattern: &str) -> usize {
         match pattern.len() {
-            0 => crate::split::words(subject).iter().count(),
+            0 => crate::split::words(subject).len(),
             _ => subject
                 .split_terminator(pattern)
-                .collect::<Vec<_>>()
-                .iter()
                 .count(),
         }
     }
@@ -187,7 +185,7 @@ pub fn count_unique_words(subject: &str, pattern: &str) -> usize {
         0 => crate::split::words(subject),
         _ => subject.split_terminator(pattern).collect::<Vec<_>>(),
     };
-    if words.len() == 0 {
+    if words.is_empty() {
         return 0;
     };
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -53,9 +53,9 @@ pub fn escape_regexp(subject: &str) -> String {
         0 => "".to_string(),
         _ => {
             let mut res = String::new();
-            for c in crate::split::chars(&subject) {
-                let push_char = if key.contains(&c) {
-                    format!("\\{}", &c)
+            for c in crate::split::chars(subject) {
+                let push_char = if key.contains(c) {
+                    format!("\\{}", c)
                 } else {
                     c.to_string()
                 };

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -22,12 +22,12 @@ pub fn escape_html(subject: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => subject
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\"", "&quot;")
-            .replace("'", "&#x27;")
-            .replace("`", "&#x60;"),
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&#x27;")
+            .replace('`', "&#x60;"),
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -23,7 +23,7 @@ use regex::Regex;
 /// // => [3, 5]
 /// ```
 pub fn index_all(subject: &str, search: &str, from_index: usize) -> Vec<usize> {
-    if subject.is_empty() || crate::count::count(&subject) < from_index {
+    if subject.is_empty() || crate::count::count(subject) < from_index {
         return vec![];
     }
     let string_slice = &subject[subject.char_indices().nth(from_index).unwrap().0..];
@@ -61,7 +61,7 @@ pub fn index_of(subject: &str, search: &str, from_index: usize) -> i8 {
     match search.len() {
         0 => 0,
         _ => {
-            if crate::count::count(&subject) < from_index {
+            if crate::count::count(subject) < from_index {
                 return -1;
             }
             let string_slice = &subject[subject.char_indices().nth(from_index).unwrap().0..];
@@ -106,7 +106,7 @@ pub fn last_index_of(subject: &str, search: &str, from_index: usize) -> i8 {
     match search.len() {
         0 => 0,
         _ => {
-            if crate::count::count(&subject) < from_index {
+            if crate::count::count(subject) < from_index {
                 return -1;
             }
             let string_slice = &subject[subject.char_indices().nth(from_index).unwrap().0..];
@@ -148,7 +148,7 @@ pub fn last_index_of(subject: &str, search: &str, from_index: usize) -> i8 {
 /// // => 2
 /// ```
 pub fn search(subject: &str, pattern: &str, from_index: usize) -> i8 {
-    if from_index >= crate::split::chars(&subject).len() {
+    if from_index >= crate::split::chars(subject).len() {
         return -1;
     }
     match pattern.len() {
@@ -158,7 +158,7 @@ pub fn search(subject: &str, pattern: &str, from_index: usize) -> i8 {
                 Ok(re) => re,
                 Err(_) => return -1,
             };
-            match re.find_at(&subject, from_index) {
+            match re.find_at(subject, from_index) {
                 None => -1,
                 Some(x) => x.start() as i8,
             }

--- a/src/manipulate.rs
+++ b/src/manipulate.rs
@@ -182,7 +182,7 @@ fn pad_left_right(subject: &str, length: usize, pad: &str, pad_mode: PadMode) ->
             } else {
                 width / 2
             };
-            let add = if width % 2 != 0 { 1 } else { 0 };
+            let add = usize::from(width % 2 != 0);
             let prefix = string_to_add[..middle].join("");
             let sufix = string_to_add[..middle + add].join("");
             format!("{}{}{}", prefix, subject, sufix)
@@ -467,10 +467,10 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
     let subject_len = crate::count::count(subject);
     fn calculate_start_position(start: isize, subject_len: usize) -> usize {
         if start < 0 {
-            if start.abs() as usize > subject_len {
+            if start.unsigned_abs() > subject_len {
                 0
             } else {
-                subject_len - start.abs() as usize
+                subject_len - start.unsigned_abs()
             }
         } else if (start as usize) >= subject_len {
             subject_len

--- a/src/manipulate.rs
+++ b/src/manipulate.rs
@@ -85,8 +85,8 @@ pub fn insert(subject: &str, to_insert: &str, position: usize) -> String {
     } else {
         position
     };
-    let prefix = crate::split::chars(&subject)[..insert_position].join("");
-    let sufix = crate::split::chars(&subject)[insert_position..].join("");
+    let prefix = crate::split::chars(subject)[..insert_position].join("");
+    let sufix = crate::split::chars(subject)[insert_position..].join("");
     format!("{}{}{}", prefix, to_insert, sufix)
 }
 
@@ -142,14 +142,14 @@ pub fn latinise(subject: &str) -> String {
 /// // => " dog "
 /// ```
 pub fn pad(subject: &str, length: usize, pad: &str) -> String {
-    let subject_len = crate::count::count_graphemes(&subject);
+    let subject_len = crate::count::count_graphemes(subject);
     match subject_len {
         0 => "".to_string(),
         _ => {
             if subject_len >= length {
                 subject.to_string()
             } else {
-                pad_left_right(&subject, length, &pad, PadMode::Both)
+                pad_left_right(subject, length, pad, PadMode::Both)
             }
         }
     }
@@ -163,7 +163,7 @@ enum PadMode {
 }
 
 fn pad_left_right(subject: &str, length: usize, pad: &str, pad_mode: PadMode) -> String {
-    let width = length - crate::count::count_graphemes(&subject);
+    let width = length - crate::count::count_graphemes(subject);
     let to_add = if pad.is_empty() { " " } else { pad };
     let times = width / to_add.len();
     let str_to_add = to_add.repeat(times + 1);
@@ -215,14 +215,14 @@ fn pad_left_right(subject: &str, length: usize, pad: &str, pad_mode: PadMode) ->
 /// // => "  dog"
 /// ```
 pub fn pad_left(subject: &str, length: usize, pad: &str) -> String {
-    let subject_len = crate::count::count_graphemes(&subject);
+    let subject_len = crate::count::count_graphemes(subject);
     match subject_len {
         0 => "".to_string(),
         _ => {
             if subject_len >= length {
                 subject.to_string()
             } else {
-                pad_left_right(&subject, length, &pad, PadMode::Left)
+                pad_left_right(subject, length, pad, PadMode::Left)
             }
         }
     }
@@ -251,14 +251,14 @@ pub fn pad_left(subject: &str, length: usize, pad: &str) -> String {
 /// // => "dog  "
 /// ```
 pub fn pad_right(subject: &str, length: usize, pad: &str) -> String {
-    let subject_len = crate::count::count_graphemes(&subject);
+    let subject_len = crate::count::count_graphemes(subject);
     match subject_len {
         0 => "".to_string(),
         _ => {
             if subject_len >= length {
                 subject.to_string()
             } else {
-                pad_left_right(&subject, length, &pad, PadMode::Right)
+                pad_left_right(subject, length, pad, PadMode::Right)
             }
         }
     }
@@ -317,13 +317,13 @@ pub fn replace(subject: &str, pattern: &str, replacement: &str) -> String {
     if subject.is_empty() || pattern.is_empty() {
         return subject.to_string();
     }
-    match index::index_of(&subject, &pattern, 0) {
+    match index::index_of(subject, pattern, 0) {
         -1 => subject.to_string(),
         x => splice(
-            &subject,
+            subject,
             x as isize,
-            crate::count::count(&pattern),
-            &replacement,
+            crate::count::count(pattern),
+            replacement,
         ),
     }
 }
@@ -464,7 +464,7 @@ pub fn slugify(subject: &str) -> String {
 /// // => "year"
 /// ```
 pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) -> String {
-    let subject_len = crate::count::count(&subject);
+    let subject_len = crate::count::count(subject);
     fn calculate_start_position(start: isize, subject_len: usize) -> usize {
         if start < 0 {
             if start.abs() as usize > subject_len {
@@ -485,9 +485,9 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
             _ => {
                 let insert_position = calculate_start_position(start, subject_len);
                 if insert_position >= subject_len {
-                    format!("{}{}", &subject, &to_add)
+                    format!("{}{}", subject, to_add)
                 } else {
-                    insert(&subject, &to_add, insert_position)
+                    insert(subject, to_add, insert_position)
                 }
             }
         },
@@ -501,9 +501,9 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
 
             format!(
                 "{}{}{}",
-                crate::chop::first(&subject, start_position),
-                &to_add,
-                crate::chop::slice(&subject, end_position as isize, 0)
+                crate::chop::first(subject, start_position),
+                to_add,
+                crate::chop::slice(subject, end_position as isize, 0)
             )
         }
     }
@@ -529,7 +529,7 @@ pub fn splice(subject: &str, start: isize, delete_count: usize, to_add: &str) ->
 /// // => "Mother nature"
 /// ```
 pub fn trim(subject: &str, whitespace: &str) -> String {
-    trim_left_or_right(&subject, &whitespace, true, true)
+    trim_left_or_right(subject, whitespace, true, true)
 }
 
 /// Removes whitespaces from the left side of the `subject`.
@@ -552,7 +552,7 @@ pub fn trim(subject: &str, whitespace: &str) -> String {
 /// // => "Mother nature "
 /// ```
 pub fn trim_left(subject: &str, whitespace: &str) -> String {
-    trim_left_or_right(&subject, &whitespace, true, false)
+    trim_left_or_right(subject, whitespace, true, false)
 }
 
 /// Removes whitespaces from the right side of the `subject`.
@@ -575,7 +575,7 @@ pub fn trim_left(subject: &str, whitespace: &str) -> String {
 /// // => " Mother nature"
 /// ```
 pub fn trim_right(subject: &str, whitespace: &str) -> String {
-    trim_left_or_right(&subject, &whitespace, false, true)
+    trim_left_or_right(subject, whitespace, false, true)
 }
 
 fn trim_left_or_right(subject: &str, whitespace: &str, to_left: bool, to_right: bool) -> String {
@@ -624,14 +624,14 @@ fn trim_left_or_right(subject: &str, whitespace: &str, to_left: bool, to_right: 
 /// // => "00123"
 /// ```
 pub fn zfill(subject: &str, length: usize) -> String {
-    let subject_len = crate::count::count_graphemes(&subject);
+    let subject_len = crate::count::count_graphemes(subject);
     match subject_len {
         0 => "".to_string(),
         _ => {
             if subject_len >= length {
                 subject.to_string()
             } else {
-                pad_left_right(&subject, length, "0", PadMode::Left)
+                pad_left_right(subject, length, "0", PadMode::Left)
             }
         }
     }
@@ -662,8 +662,8 @@ pub fn tr(subject: &str, from: &str, to: &str) -> String {
         return subject.to_owned();
     }
     let mut result = String::from(subject);
-    let from_symbols = crate::split::graphemes(&from);
-    let to_symbols = crate::split::graphemes(&to);
+    let from_symbols = crate::split::graphemes(from);
+    let to_symbols = crate::split::graphemes(to);
     let to_len = to_symbols.len();
 
     for (i, c) in from_symbols.iter().enumerate() {
@@ -695,7 +695,7 @@ pub fn tr(subject: &str, from: &str, to: &str) -> String {
 /// // => "Hello\nworld"
 /// ```
 pub fn word_wrap(subject: &str, width: usize, newline: &str, indent: &str) -> String {
-    let mut subject_len = crate::count::count_graphemes(&subject);
+    let mut subject_len = crate::count::count_graphemes(subject);
     if subject.is_empty() || (subject_len < width && indent.is_empty()) {
         return subject.to_owned();
     }

--- a/src/manipulate.rs
+++ b/src/manipulate.rs
@@ -51,7 +51,7 @@ pub fn expand_tabs(subject: &str, tabsize: usize) -> String {
     if subject.is_empty() {
         "".to_string()
     } else {
-        subject.replace("\t", &" ".repeat(tabsize))
+        subject.replace('\t', &" ".repeat(tabsize))
     }
 }
 
@@ -435,7 +435,7 @@ pub fn slugify(subject: &str) -> String {
     if subject.is_empty() {
         "".to_string()
     } else {
-        crate::split::words(unidecode(subject).replace("'", "").to_lowercase().trim()).join("-")
+        crate::split::words(unidecode(subject).replace('\'', "").to_lowercase().trim()).join("-")
     }
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -50,7 +50,7 @@ pub fn ends_with(subject: &str, end: &str) -> bool {
 /// // => true
 /// ```
 pub fn includes(subject: &str, search: &str, position: usize) -> bool {
-    let subject_len = crate::count::count(&subject);
+    let subject_len = crate::count::count(subject);
     if subject_len < position {
         return false;
     }
@@ -59,7 +59,7 @@ pub fn includes(subject: &str, search: &str, position: usize) -> bool {
     }
     subject.to_owned()[subject.char_indices().nth(position).unwrap().0..]
         .to_string()
-        .contains(&search)
+        .contains(search)
 }
 
 /// Checks whether `subject` contains only alpha characters.
@@ -87,19 +87,19 @@ pub fn includes(subject: &str, search: &str, position: usize) -> bool {
 /// // => true
 /// ```
 pub fn is_alpha(subject: &str) -> bool {
-    if is_empty(&subject) {
+    if is_empty(subject) {
         false
     } else {
-        is_alpha_or_alphadigit(&subject, false)
+        is_alpha_or_alphadigit(subject, false)
     }
 }
 
 fn is_alpha_or_alphadigit(subject: &str, count_digits: bool) -> bool {
     let mut subject_is_ok = true;
-    let subject_grapheme_len = crate::count::count_graphemes(&subject);
+    let subject_grapheme_len = crate::count::count_graphemes(subject);
     let mut current_pos = 0;
     while current_pos < subject_grapheme_len {
-        let current_char = crate::chop::grapheme_at(&subject, current_pos);
+        let current_char = crate::chop::grapheme_at(subject, current_pos);
         if (!count_digits
             && (is_digit(&current_char)
                 || is_blank(&current_char)
@@ -141,10 +141,10 @@ fn is_alpha_or_alphadigit(subject: &str, count_digits: bool) -> bool {
 /// // => true
 /// ```
 pub fn is_alphadigit(subject: &str) -> bool {
-    if is_empty(&subject) {
+    if is_empty(subject) {
         false
     } else {
-        is_alpha_or_alphadigit(&subject, true)
+        is_alpha_or_alphadigit(subject, true)
     }
 }
 
@@ -199,7 +199,7 @@ pub fn is_blank(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_camel_case(subject: &str) -> bool {
-    subject == crate::case::camel_case(&subject)
+    subject == crate::case::camel_case(subject)
 }
 
 /// Checks whether `subject` is capitalized and the rest of `subject` is converted to lower case.
@@ -225,7 +225,7 @@ pub fn is_camel_case(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_capitalize(subject: &str) -> bool {
-    is_capitalize_or_decapitalize(&subject, true)
+    is_capitalize_or_decapitalize(subject, true)
 }
 
 /// Checks whether `subject` is decapitalized and the rest of `subject` is converted to lower case.
@@ -251,15 +251,15 @@ pub fn is_capitalize(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_decapitalize(subject: &str) -> bool {
-    is_capitalize_or_decapitalize(&subject, false)
+    is_capitalize_or_decapitalize(subject, false)
 }
 
 fn is_capitalize_or_decapitalize(subject: &str, if_capitalize: bool) -> bool {
     match subject.len() {
         0 => true,
         _ => {
-            let first_letter = crate::chop::first(&subject, 1);
-            let the_rest = crate::chop::slice(&subject, 1, 0);
+            let first_letter = crate::chop::first(subject, 1);
+            let the_rest = crate::chop::slice(subject, 1, 0);
             let first_letter_to_check = if if_capitalize {
                 is_uppercase(&first_letter)
             } else {
@@ -297,7 +297,7 @@ pub fn is_digit(subject: &str) -> bool {
         return true;
     }
 
-    crate::split::chars(&subject)
+    crate::split::chars(subject)
         .iter()
         .filter(|c| {
             let mut current_char = String::new();
@@ -359,7 +359,7 @@ pub fn is_empty(subject: &str) -> bool {
 /// // => false
 /// ```
 pub fn is_foreign_key(subject: &str) -> bool {
-    subject == crate::chop::foreign_key(&subject)
+    subject == crate::chop::foreign_key(subject)
 }
 
 /// Checks whether `subject` has only lower case characters.
@@ -441,7 +441,7 @@ pub fn is_lower_first(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_kebab_case(subject: &str) -> bool {
-    subject == crate::case::kebab_case(&subject)
+    subject == crate::case::kebab_case(subject)
 }
 
 /// Checks whether `subject` is numeric.
@@ -520,7 +520,7 @@ pub fn is_numeric(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_pascal_case(subject: &str) -> bool {
-    subject == crate::case::pascal_case(&subject)
+    subject == crate::case::pascal_case(subject)
 }
 
 /// Checks whether `subject` is SHOUTY-KEBAB-CASED.
@@ -546,7 +546,7 @@ pub fn is_pascal_case(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_shouty_kebab_case(subject: &str) -> bool {
-    subject == crate::case::shouty_kebab_case(&subject)
+    subject == crate::case::shouty_kebab_case(subject)
 }
 
 /// Checks whether `subject` is snake_cased.
@@ -572,7 +572,7 @@ pub fn is_shouty_kebab_case(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_snake_case(subject: &str) -> bool {
-    subject == crate::case::snake_case(&subject)
+    subject == crate::case::snake_case(subject)
 }
 
 /// Checks whether `subject` is SHOUTY_SNAKE_CASED.
@@ -598,7 +598,7 @@ pub fn is_snake_case(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_shouty_snake_case(subject: &str) -> bool {
-    subject == crate::case::shouty_snake_case(&subject)
+    subject == crate::case::shouty_snake_case(subject)
 }
 
 /// Checks whether `subject` is a titlecased string and there is at least one character.
@@ -623,7 +623,7 @@ pub fn is_title(subject: &str) -> bool {
     if subject.is_empty() {
         return false;
     }
-    let words = crate::split::words(&subject);
+    let words = crate::split::words(subject);
     let subject_len = words.len();
     words
         .iter()
@@ -631,7 +631,7 @@ pub fn is_title(subject: &str) -> bool {
             let mut res = String::with_capacity(w.len());
             for (i, c) in crate::split::chars(w).iter().enumerate() {
                 if (i == 0 && c == &c.to_uppercase()) || (i > 0 && c == &c.to_lowercase()) {
-                    res.push_str(&c)
+                    res.push_str(c)
                 }
             }
             res.len() == w.len()
@@ -663,7 +663,7 @@ pub fn is_title(subject: &str) -> bool {
 /// // => true
 /// ```
 pub fn is_train_case(subject: &str) -> bool {
-    subject == crate::case::train_case(&subject)
+    subject == crate::case::train_case(subject)
 }
 
 /// Checks whether `subject` has only upper case characters.
@@ -761,7 +761,7 @@ fn is_upper_or_lowercase(subject: &str, lowercase: bool) -> bool {
 /// // => true
 /// ```
 pub fn matches(subject: &str, pattern: &str, position: usize) -> bool {
-    let subject_len = crate::split::chars(&subject).len();
+    let subject_len = crate::split::chars(subject).len();
     if subject_len == 0 {
         return false;
     }
@@ -775,7 +775,7 @@ pub fn matches(subject: &str, pattern: &str, position: usize) -> bool {
                 Ok(re) => re,
                 Err(_) => return false,
             };
-            re.is_match_at(&subject, position)
+            re.is_match_at(subject, position)
         }
     }
 }
@@ -803,7 +803,7 @@ pub fn matches(subject: &str, pattern: &str, position: usize) -> bool {
 /// // => true
 /// ```
 pub fn query(subject: &str, search: &str, position: usize) -> bool {
-    let subject_len = crate::count::count(&subject);
+    let subject_len = crate::count::count(subject);
     if subject_len < position {
         return false;
     }
@@ -811,8 +811,8 @@ pub fn query(subject: &str, search: &str, position: usize) -> bool {
         return true;
     }
     let mut i: usize = 0;
-    let q = crate::split::chars(&search);
-    let q_len = crate::split::chars(&search).len();
+    let q = crate::split::chars(search);
+    let q_len = crate::split::chars(search).len();
     crate::split::chars(&subject.to_owned()[subject.char_indices().nth(position).unwrap().0..])
         .into_iter()
         .filter(|c| {
@@ -828,7 +828,7 @@ pub fn query(subject: &str, search: &str, position: usize) -> bool {
             }
         })
         .count()
-        == crate::count::count(&search)
+        == crate::count::count(search)
 }
 
 /// Checks whether `subject` starts with `start`.

--- a/src/split.rs
+++ b/src/split.rs
@@ -174,5 +174,5 @@ pub fn code_points(subject: &str) -> Vec<u16> {
     if subject.is_empty() {
         return vec![];
     }
-    stfu8::decode_u16(&subject).unwrap()
+    stfu8::decode_u16(subject).unwrap()
 }

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -24,8 +24,8 @@ pub fn strip_bom(subject: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
         _ => {
-            if crate::chop::first(&subject, 1) == "\u{FEFF}" {
-                crate::chop::slice(&subject, 1, 0)
+            if crate::chop::first(subject, 1) == "\u{FEFF}" {
+                crate::chop::slice(subject, 1, 0)
             } else {
                 subject.to_string()
             }
@@ -52,7 +52,7 @@ pub fn strip_bom(subject: &str) -> String {
 pub fn strip_tags(subject: &str) -> String {
     match subject.len() {
         0 => "".to_string(),
-        _ => strip_html_tags(&subject),
+        _ => strip_html_tags(subject),
     }
 }
 
@@ -175,7 +175,7 @@ fn strip_html_tags(subject: &str) -> String {
         if advance {
             match state {
                 StateMode::Output => {
-                    output.push_str(&c);
+                    output.push_str(c);
                 }
                 StateMode::Html => {}
                 _ => {}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -119,7 +119,7 @@ pub const WHITESPACE: &str = " \t\n\r";
 /// of that string.
 /// https://github.com/chowdhurya/rust-unidecode/blob/master/src/lib.rs
 pub fn unidecode(s: &str) -> String {
-    s.chars().map(|ch| unidecode_char(ch)).collect()
+    s.chars().map(unidecode_char).collect()
 }
 
 /// Takes a single Unicode character and returns an ASCII
@@ -127,7 +127,7 @@ pub fn unidecode(s: &str) -> String {
 /// https://github.com/chowdhurya/rust-unidecode/blob/master/src/lib.rs
 #[inline]
 pub fn unidecode_char(ch: char) -> &'static str {
-    MAPPING.get(ch as usize).map(|&s| s).unwrap_or("")
+    MAPPING.get(ch as usize).copied().unwrap_or("")
 }
 
 /// Unicode mapping

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,7 +132,7 @@ pub fn unidecode_char(ch: char) -> &'static str {
 
 /// Unicode mapping
 /// https://github.com/chowdhurya/rust-unidecode/blob/master/src/data.rs
-static MAPPING: [&'static str; 0xffff] = [
+static MAPPING: [&str; 0xffff] = [
     "\u{0}",
     "\u{1}",
     "\u{2}",


### PR DESCRIPTION
Various cleanups suggested by `cargo clippy` with rust 1.65.0.

I find it's generally helpful to address these, even when they're marginal readability issues, since it makes more serious issues easier to detect.