### PR TITLE
Fix bounds check in strip_html_tags

### DIFF
--- a/src/strip.rs
+++ b/src/strip.rs
@@ -78,12 +78,14 @@ fn strip_html_tags(subject: &str) -> String {
     let mut depth = 0;
     let mut output = String::with_capacity(length);
     let mut quote = String::with_capacity(4);
-    for (i, c) in crate::split::graphemes(subject).iter().enumerate() {
+    let g = graphemes(subject);
+    let g_length = g.len();
+    for (i, c) in g.iter().enumerate() {
         let mut advance = false;
         match *c {
             "<" => {
                 if !quote.is_empty() {
-                } else if i + 2 < length
+                } else if i + 2 < g_length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 2).as_str(),
                         "< ",
@@ -102,7 +104,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "!" => {
                 if state == StateMode::Html
-                    && i + 2 < length
+                    && i + 2 < g_length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 2).as_str(),
                         "<!",
@@ -116,7 +118,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "-" => {
                 if state == StateMode::Exclamation
-                    && i + 3 < length
+                    && i + 3 < g_length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 3).as_str(),
                         "!--",
@@ -142,7 +144,7 @@ fn strip_html_tags(subject: &str) -> String {
             }
             "E" | "e" => {
                 if state == StateMode::Exclamation
-                    && i + 7 < length
+                    && i + 7 < g_length
                     && crate::query::query(
                         unicode_string_range(subject, i, i + 7).as_str(),
                         "doctype",
@@ -161,7 +163,7 @@ fn strip_html_tags(subject: &str) -> String {
                 } else if state == StateMode::Html
                     || state == StateMode::Exclamation
                     || state == StateMode::Comment
-                        && i + 3 < length
+                        && i + 3 < g_length
                         && crate::query::query(
                             unicode_string_range(subject, i, i + 3).as_str(),
                             "-->",

--- a/tests/unit/strip.rs
+++ b/tests/unit/strip.rs
@@ -235,4 +235,8 @@ fn partial_directive() {
     assert_eq!(voca_rs::strip::strip_tags("</a"), "");
     assert_eq!(voca_rs::strip::strip_tags("<!"), "");
     assert_eq!(voca_rs::strip::strip_tags("<!-"), "");
+    assert_eq!(voca_rs::strip::strip_tags("á<!"), "á");
+    // Should maybe keep the lose both angle brackets?
+    assert_eq!(voca_rs::strip::strip_tags(">天地不仁<"), ">天地不仁");
+    assert_eq!(voca_rs::strip::strip_tags("\u{00a0}<!"), "\u{a0}");
 }


### PR DESCRIPTION
Here's a quick follow-up fix in the same style. Ideally I think it would be better to scan through the `Vec<&str>` returned by UnicodeSegmentation with either a moving index or filtered through a custom stateful iterator so the lookahead bounds come naturally and copies are minimized. But hopefully this achieves correct behaviour with minimal changes.

The iteration is over graphemes, not bytes, so if the input contains any non-ascii characters, it's still possible to read off the end doing look-ahead. Clamp to the length of the grapheme iterator instead of the number of input bytes.

Resolves https://github.com/a-merezhanyi/voca_rs/issues/21